### PR TITLE
Changed linear transformation mapping to R^n->R^m

### DIFF
--- a/course-materials/workbook/LinAlgWorkbook.tex
+++ b/course-materials/workbook/LinAlgWorkbook.tex
@@ -1492,7 +1492,7 @@ To help you get started with meta-cognition, I listed learning goals in
         us to compute a new vector \(T_A(v) = Av\) of size \(m\). This is
         the basic example of what we will eventually call a \terminology{linear
         transformation}.\begin{align*}
-\mathbb{R}^m & \xrightarrow[]{T_A} \mathbb{R}^n\\
+\mathbb{R}^n & \xrightarrow[]{T_A} \mathbb{R}^m\\
 v & \xmapsto[]{\phantom{T_A}} Av.
 \end{align*}
         One of our long term goals is to find a way to think about the geometry


### PR DESCRIPTION
The text says "for every vector v of size n, the matrix A allows us to
compute a new vector T_A(v)=Av of size m." Therefore, my understanding
is that the mapping should be R^n->R^m instead of R^m->R^n.
